### PR TITLE
Feat/integrate rewards to flow

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -12,6 +12,7 @@ import ReportedInfractions from './pages/ReportedInfractions';
 import Infractions from './pages/Infractions';
 import VoteInfractions from './pages/VoteInfractions';
 import VoteNext from './pages/VoteNext';
+import Pay from './pages/Pay';
 
 import AuthenticatedRoute from './components/AuthenticatedRoute';
 import UnauthenticatedRoute from './components/UnauthenticatedRoute';
@@ -30,6 +31,7 @@ const Routes = () => (
       <AuthenticatedRoute path="/infractions/:id" exact component={Infractions} />
       <AuthenticatedRoute path="/vote/:id" exact component={VoteInfractions} />
       <AuthenticatedRoute path="/vote" exact component={VoteNext} />
+      <AuthenticatedRoute path="/pay/:id" exact component={Pay} />
       <Route component={NotFound} />
     </Switch>
   </MainTemplate>

--- a/src/components/DashBoardCard/index.js
+++ b/src/components/DashBoardCard/index.js
@@ -6,7 +6,7 @@ import {
 
 import useStyles from './styles';
 
-function DashboardCard({ mainText, secondaryText }) {
+function DashboardCard({ mainText, secondaryText, isReward }) {
   const classes = useStyles();
 
   return (
@@ -18,7 +18,7 @@ function DashboardCard({ mainText, secondaryText }) {
         { secondaryText || secondaryText === 0
           ? (
             <Typography variant="body2" color="textSecondary">
-              {secondaryText}
+              {isReward ? secondaryText / 10 : secondaryText}
             </Typography>
           )
           : <LinearProgress />}

--- a/src/components/InfractionDetails/consts.js
+++ b/src/components/InfractionDetails/consts.js
@@ -22,3 +22,18 @@ export const headers = {
   marca: 'Marca',
   modelo: 'Modelo',
 };
+
+
+export const stages = [
+  'Revisión comunitaria',
+  'Revisión en departamento',
+  'Revisión en juzgado',
+  'Aprobada por juzgado',
+  'Periodo de pago',
+  'Pagada',
+  'Reclamada',
+  'Rechazada por la comunidad',
+  'Rechazada por departamento',
+  'Rechazada por juzgado',
+  'Rechazo total',
+];

--- a/src/components/InfractionDetails/index.js
+++ b/src/components/InfractionDetails/index.js
@@ -30,9 +30,10 @@ function InfractionDetails({
   }, [subspace, infractionContract, match.params.id]);
 
   useEffect(() => {
-    if (infractionContract) return;
+    if (stage !== '5') return;
+    if (rewardsContract) return;
     setRewardsContract(subspace.contract({ abi: rewardsAbi, address: rewardsAddress }));
-  }, [subspace, infractionContract, match.params.id]);
+  }, [subspace, rewardsContract, stage]);
 
   useEffect(() => {
     if (!infractionContract) return;

--- a/src/components/RewardsCard/index.js
+++ b/src/components/RewardsCard/index.js
@@ -30,6 +30,7 @@ function Rewards() {
     <DashBoardCard
       mainText="Rewards Tandil"
       secondaryText={rewardsObservable}
+      isReward
     />
   );
 }

--- a/src/pages/Admin/InfractionTabPanel.js
+++ b/src/pages/Admin/InfractionTabPanel.js
@@ -1,22 +1,32 @@
+/* eslint-disable radix */
 import React from 'react';
 import {
-  LinearProgress, Grid, Button,
+  LinearProgress, Grid, Button, TextField,
 } from '@material-ui/core';
 import Pagination from '@material-ui/lab/Pagination';
 import { makeStyles } from '@material-ui/core/styles';
 import InfractionDetails from '../../components/InfractionDetails';
 import TabPanel from './TabPanel';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   grid: {
     'text-align': 'center',
+  },
+  input: {
+    padding: theme.spacing(2, 0, 0, 0),
+    justifyContent: 'center',
+    justifyItems: 'center',
+    alignItems: 'center',
+    alignContent: 'center',
   },
 }));
 
 const InfractionTabPanel = ({
-  value, index, address, totalInfractions, page, handleChange, handleAction,
+  value, index, address, totalInfractions, page, handleChange, handleAction, handleInput,
+  inputValue,
 }) => {
   const classes = useStyles();
+
   return (
     <TabPanel value={value} index={index}>
       {!address
@@ -25,18 +35,32 @@ const InfractionTabPanel = ({
           <>
             <InfractionDetails address={address} />
             {handleAction && (
-              <Grid container spacing={2}>
-                <Grid item xs={6}>
-                  <Button fullWidth variant="contained" onClick={() => handleAction(false)}>
-                    Invalida
-                  </Button>
+              <>
+                <Grid container spacing={2} className={classes.input}>
+                  <Grid item xs={3}>
+                    <TextField
+                      id="reward"
+                      label="Valor recompensa en UF"
+                      type="number"
+                      onChange={(e) => { handleInput(parseInt(e.target.value)); }}
+                      value={inputValue}
+                      fullWidth
+                    />
+                  </Grid>
                 </Grid>
-                <Grid item xs={6}>
-                  <Button fullWidth variant="contained" color="secondary" onClick={() => handleAction(true)}>
-                    Valida
-                  </Button>
+                <Grid container spacing={2}>
+                  <Grid item xs={6}>
+                    <Button fullWidth variant="contained" onClick={() => handleAction(false)}>
+                      Invalida
+                    </Button>
+                  </Grid>
+                  <Grid item xs={6}>
+                    <Button fullWidth variant="contained" color="secondary" onClick={() => handleAction(true)}>
+                      Valida
+                    </Button>
+                  </Grid>
                 </Grid>
-              </Grid>
+              </>
             )}
             <Grid container spacing={2} className={classes.grid}>
               <Grid item xs={12}>

--- a/src/pages/Admin/index.js
+++ b/src/pages/Admin/index.js
@@ -27,6 +27,7 @@ export default function Admin() {
   const [infractionFactoryContract, setInfractionFactoryContract] = useState();
   const [totalInfractions, setTotalInfractions] = useState(0);
   const [page, setPage] = useState(1);
+  const [input, setInput] = useState(30);
   const [address, setAddress] = useState();
   const [infractionContract, setInfractionContract] = useState();
   const [myInfractionsObservable$, setMyInfractionsObservable] = useState();
@@ -97,21 +98,22 @@ export default function Admin() {
 
   const handleAction = async (value) => {
     if (!infractionContract) return;
+
     const methods = {
       1: {
         true: 'departamentApproves()',
         false: 'departamentRejects()',
       },
       2: {
-        true: 'courtApproves()',
+        true: 'courtApproves(uint256)',
         false: 'courtRejects()',
       },
     };
     const method = methods[tab][value];
-    infractionContract.methods[method]()
+    infractionContract.methods[method](input * 10) // Reward has 1 decimal
       .send({ from: subspace.web3.eth.defaultAccount, gasLimit: 3000000 })
       .then((r) => {
-        console.log('saved', r);
+        console.log('done', r);
       });
   };
 
@@ -136,6 +138,8 @@ export default function Admin() {
           page={page}
           handleChange={handlePageChange}
           handleAction={i !== 0 ? handleAction : undefined}
+          handleInput={i === 2 ? setInput : undefined}
+          inputValue={input}
           key={label}
         />
       ))}

--- a/src/pages/Infractions/index.js
+++ b/src/pages/Infractions/index.js
@@ -6,7 +6,7 @@ import InfractionDetails from '../../components/InfractionDetails';
 function Page({ match }) {
   return (
     <Container>
-      <InfractionDetails address={match.params.id} />
+      <InfractionDetails address={match.params.id} showStage />
     </Container>
   );
 }

--- a/src/pages/Pay/index.js
+++ b/src/pages/Pay/index.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import Container from '@material-ui/core/Container';
+import InfractionDetails from '../../components/InfractionDetails';
+
+
+function Pay({ match }) {
+  return (
+    <Container>
+      <InfractionDetails address={match.params.id} showStage showPay />
+    </Container>
+  );
+}
+
+export default Pay;

--- a/src/web3/infraction/index.js
+++ b/src/web3/infraction/index.js
@@ -85,12 +85,6 @@ export const infractionAbi = [
   {
     anonymous: false,
     inputs: [],
-    name: 'overduePaimentPeriodEnds',
-    type: 'event',
-  },
-  {
-    anonymous: false,
-    inputs: [],
     name: 'paid',
     type: 'event',
   },
@@ -98,12 +92,6 @@ export const infractionAbi = [
     anonymous: false,
     inputs: [],
     name: 'ready',
-    type: 'event',
-  },
-  {
-    anonymous: false,
-    inputs: [],
-    name: 'regularPaimentPeriodEnds',
     type: 'event',
   },
   {
@@ -128,12 +116,6 @@ export const infractionAbi = [
     anonymous: false,
     inputs: [],
     name: 'rejectedByDepartment',
-    type: 'event',
-  },
-  {
-    anonymous: false,
-    inputs: [],
-    name: 'volunteerPaimentPeriodEnds',
     type: 'event',
   },
   {
@@ -222,6 +204,19 @@ export const infractionAbi = [
         internalType: 'uint8',
         name: '',
         type: 'uint8',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'reward',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
       },
     ],
     stateMutability: 'view',
@@ -346,7 +341,13 @@ export const infractionAbi = [
     type: 'function',
   },
   {
-    inputs: [],
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_reward',
+        type: 'uint256',
+      },
+    ],
     name: 'courtApproves',
     outputs: [],
     stateMutability: 'nonpayable',
@@ -355,27 +356,6 @@ export const infractionAbi = [
   {
     inputs: [],
     name: 'courtRejects',
-    outputs: [],
-    stateMutability: 'nonpayable',
-    type: 'function',
-  },
-  {
-    inputs: [],
-    name: 'endVolunteerPayment',
-    outputs: [],
-    stateMutability: 'nonpayable',
-    type: 'function',
-  },
-  {
-    inputs: [],
-    name: 'endRegularPayment',
-    outputs: [],
-    stateMutability: 'nonpayable',
-    type: 'function',
-  },
-  {
-    inputs: [],
-    name: 'endOverduePayment',
     outputs: [],
     stateMutability: 'nonpayable',
     type: 'function',

--- a/src/web3/rewards/index.js
+++ b/src/web3/rewards/index.js
@@ -1,6 +1,6 @@
 export const rewardsDeployBlock = process.env.REACT_APP_REWARDS_TANDIL_BLOCK;
 export const rewardsAddress = process.env.REACT_APP_REWARDS_TANDIL_ADDRESS;
-console.log(rewardsDeployBlock, rewardsAddress);
+
 export const rewardsAbi = [
   {
     inputs: [],
@@ -289,11 +289,6 @@ export const rewardsAbi = [
         internalType: 'address',
         name: 'infractionAddress',
         type: 'address',
-      },
-      {
-        internalType: 'uint256',
-        name: 'amount',
-        type: 'uint256',
       },
     ],
     name: 'claimReward',


### PR DESCRIPTION
- ## Visualización de estado actual en los detalles de la infracción
Dentro de los detalles de la infracción, bajo el título de Estado
![estado](https://user-images.githubusercontent.com/5481398/84961802-986f9f80-b0db-11ea-9a2f-92f06428d88d.png)

---
- ## Simulación de pago en `/pay/:id`

En `/pay/0x....`, colocando el address de la infracción se puede simular el pago por fuera del sistema. Podríamos en un futuro actualizarlo para soportar pagos mediante cripto.

![simulate](https://user-images.githubusercontent.com/5481398/84961474-c30d2880-b0da-11ea-9831-ec47e036a5cb.png)
---
- ## Reclamar recompensa una vez pagada

Cuando la infracción se encuentra en estado pagada, aparece un nuevo botón para reclamar la recompensa asociada la misma. El valor de la recompensa lo asigna un administrador al aprobarla.

![claim](https://user-images.githubusercontent.com/5481398/84961482-cd2f2700-b0da-11ea-8cb1-d7c4e0b37df0.png)

---
- ## Actualización en dashboard

Visualización en el dashboard de las recompensas ganadas hasta el momento.

![dashboard](https://user-images.githubusercontent.com/5481398/84961644-33b44500-b0db-11ea-9703-7efde3ab0db7.png)

---
- ## Actualización en metamask como custom token 

Se puede ver los tokens acumulados mediante metamask, como un custom token.

(0x48DC39FDD800220BfCDFae4E03A6EC593bc988A7)
![tnl](https://user-images.githubusercontent.com/5481398/84961504-dfa96080-b0da-11ea-9c6b-079f32abde87.png)
---